### PR TITLE
adds support for multiple get parameters with the same key

### DIFF
--- a/class.baseclient.php
+++ b/class.baseclient.php
@@ -312,26 +312,14 @@ class HubSpot_BaseClient {
             foreach ($params as $parameter => $value) {
               if(is_array($value)){
                 foreach($value as $subparam) {
-                  $paramstring = $paramstring . '&' . format_parameter_string($parameter, $subparam);
+                  $paramstring = $paramstring . '&' . $parameter . '=' . urlencode($subparam);  
                 }
               } else {
-                $paramstring = $paramstring . '&' . format_parameter_string($parameter, $value); 
+                $paramstring = $paramstring . '&' . $parameter . '=' . urlencode($value); 
               }
             }
         }
         return $paramstring;
-    }
-
-    /**
-     * Utility function to format a paramter string
-     *
-     * @param parameter: the parameter
-     * @param value: the value
-     *
-     * @return String
-     **/
-    protected function format_parameter_string($parameter, $value) {
-      return $parameter . '=' . urlencode($value);
     }
 
     /**


### PR DESCRIPTION
HubSpot allows for multiple get parameters with the same key and different values. In the case of the contact API an example would be the property parameter. It is possible to pass in any number of properties to be returned by adding multiple property keys with different values for each property type you want returned to the parameters string in the get request. This pull request adds support for passing in an array to the params list where each element in the array will get written as a separate key=>value pair.
